### PR TITLE
Revert "Bump dev.resteasy.tools:resteasy-parent from 2.0.3.Final to 2.0.3.Final-redhat-00001"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>dev.resteasy.tools</groupId>
         <artifactId>resteasy-parent</artifactId>
-        <version>2.0.3.Final-redhat-00001</version>
+        <version>2.0.3.Final</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
Reverts resteasy/resteasy-grpc#38

@ronsigal I think we want to roll this one back. We shouldn't use productized dependencies in the community project. I'm guessing this just slipped through because there were so many PR's.