### PR TITLE
1.0.0.Alpha3->1.0.0.Alpha4; resteasy-grpc-parent->2.0.4.Final

### DIFF
--- a/grpc-bom/pom.xml
+++ b/grpc-bom/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>dev.resteasy.grpc</groupId>
         <artifactId>resteasy-grpc-parent</artifactId>
-        <version>1.0.0.Alpha3</version>
+        <version>1.0.0.Alpha4</version>
     </parent>
 
     <artifactId>resteasy-grpc-bom</artifactId>

--- a/grpc-bridge-runtime/pom.xml
+++ b/grpc-bridge-runtime/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.resteasy.grpc</groupId>
         <artifactId>resteasy-grpc-parent</artifactId>
-        <version>1.0.0.Alpha3</version>
+        <version>1.0.0.Alpha4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>grpc-bridge-runtime</artifactId>

--- a/grpc-bridge/pom.xml
+++ b/grpc-bridge/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>dev.resteasy.grpc</groupId>
         <artifactId>resteasy-grpc-parent</artifactId>
-        <version>1.0.0.Alpha3</version>
+        <version>1.0.0.Alpha4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -71,7 +71,7 @@
         <!--dependency>
         	<groupId>dev.resteasy.grpc</groupId>
         	<artifactId>grpc-tests</artifactId>
-        	<version>1.0.0.Alpha3</version>
+        	<version>1.0.0.Alpha4</version>
         </dependency-->
     </dependencies>
 </project>

--- a/grpc-test-bom/pom.xml
+++ b/grpc-test-bom/pom.xml
@@ -32,7 +32,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <version.io.grpc>1.56.0.redhat-00001</version.io.grpc>
+        <version.io.grpc>1.54.1</version.io.grpc>
         <protoc-gen-grpc-java.version>1.51.1</protoc-gen-grpc-java.version>
         <version.org.jboss.arquillian>1.7.2.Final</version.org.jboss.arquillian>
         <version.org.wildfly.arquillian.wildfly-arquillian>5.0.1.Final</version.org.wildfly.arquillian.wildfly-arquillian>

--- a/grpc-test-bom/pom.xml
+++ b/grpc-test-bom/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>dev.resteasy.grpc</groupId>
         <artifactId>resteasy-grpc-parent</artifactId>
-        <version>1.0.0.Alpha3</version>
+        <version>1.0.0.Alpha4</version>
     </parent>
 
     <artifactId>resteasy-grpc-test-bom</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>dev.resteasy.tools</groupId>
         <artifactId>resteasy-parent</artifactId>
-        <version>2.0.3.Final</version>
+        <version>2.0.4.Final</version>
         <relativePath/>
     </parent>
 
@@ -13,7 +13,7 @@
 
     <groupId>dev.resteasy.grpc</groupId>
     <artifactId>resteasy-grpc-parent</artifactId>
-    <version>1.0.0.Alpha3</version>
+    <version>1.0.0.Alpha4</version>
     <packaging>pom</packaging>
 
     <url>https://resteasy.dev</url>
@@ -189,7 +189,7 @@
              useful for when we want to test with versions releases that have not yet been synchronized to Maven Central
              from JBoss Nexus.
          -->
-        <repository>
+        <!--repository>
             <releases>
                 <enabled>true</enabled>
                 <updatePolicy>never</updatePolicy>
@@ -202,9 +202,9 @@
             <name>JBoss Public Repository Group</name>
             <url>https://repository.jboss.org/nexus/content/groups/public/</url>
             <layout>default</layout>
-        </repository>
+        </repository-->
         <!-- Required for PicketBox, once this is removed from WildFly this can be removed -->
-        <repository>
+        <!--repository>
             <releases>
                 <enabled>true</enabled>
                 <updatePolicy>never</updatePolicy>
@@ -217,6 +217,6 @@
             <name>JBoss Enterprise Maven Repository</name>
             <url>https://maven.repository.redhat.com/ga/</url>
             <layout>default</layout>
-        </repository>
+        </repository-->
     </repositories>
 </project>

--- a/testsuite/grpc-tests/pom.xml
+++ b/testsuite/grpc-tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.resteasy.grpc</groupId>
         <artifactId>resteasy-grpc-testsuite</artifactId>
-        <version>1.0.0.Alpha3</version>
+        <version>1.0.0.Alpha4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <properties>

--- a/testsuite/grpc-tests/src/test/resources/web.xml
+++ b/testsuite/grpc-tests/src/test/resources/web.xml
@@ -1,21 +1,21 @@
 <!--
-  ~ JBoss, Home of Professional Open Source.
-  ~
-  ~ Copyright 2023 Red Hat, Inc., and individual contributors
-  ~ as indicated by the @author tags.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~     http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
+~ JBoss, Home of Professional Open Source.
+~
+~ Copyright 2023 Red Hat, Inc., and individual contributors
+~ as indicated by the @author tags.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~     http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
 
 <web-app xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
@@ -29,13 +29,13 @@
     </servlet>
 
     <!--
-       The intention is that CC1MessageBodyReaderWriter (with the help of CC1_JavabufTranslator)
-       will handle all reading and writing of data objects. Therefore, we
+      The intention is that CC1MessageBodyReaderWriter (with the help of CC1_JavabufTranslator)
+      will handle all reading and writing of data objects. Therefore, we
 
-       1. eliminate all builtin providers, and then
-       2. add back builtin providers other than MessageBodyReaders and MessageBodyWriters.
+      1. eliminate all builtin providers, and then
+      2. add back builtin providers other than MessageBodyReaders and MessageBodyWriters.
 
-     -->
+    -->
     <context-param>
         <param-name>resteasy.use.builtin.providers</param-name>
         <param-value>false</param-value>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.resteasy.grpc</groupId>
         <artifactId>resteasy-grpc-parent</artifactId>
-        <version>1.0.0.Alpha3</version>
+        <version>1.0.0.Alpha4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>resteasy-grpc-testsuite</artifactId>


### PR DESCRIPTION
Need dev.resteasy.grpc:resteasy-grpc-parent:2.0.4.Final to get maven-central-release profile.